### PR TITLE
Fix menu statement

### DIFF
--- a/app/backup_manager/app_menu.php
+++ b/app/backup_manager/app_menu.php
@@ -10,6 +10,6 @@ $apps[$x]['menu'][$y]['icon'] = "";
 $apps[$x]['menu'][$y]['path'] = "/app/backup_manager/backup.php";
 $apps[$x]['menu'][$y]['order'] = "";
 $apps[$x]['menu'][$y]['groups'][] = "superadmin";    
-$y++
+$y++;
 
 ?>


### PR DESCRIPTION
## Summary
- add a missing semicolon in the backup manager menu file

## Testing
- `php -l app/backup_manager/app_menu.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6862f2a012a8832986c1f777484e2026