### PR TITLE
Add backup manager menu with auto backup options

### DIFF
--- a/app/backup_manager/app_config.php
+++ b/app/backup_manager/app_config.php
@@ -23,4 +23,27 @@ $apps[$x]['permissions'][$y]['name'] = "backup_manager_restore";
 $apps[$x]['permissions'][$y]['uuid'] = "aedf4567-1b2c-3d4e-5f6a-7b8901cdef23";
 $apps[$x]['permissions'][$y]['groups'][] = "superadmin";
 
+// Default settings
+$y = 0;
+$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "c1e0b8a2-b7d2-4eaa-8d2a-001122334455";
+$apps[$x]['default_settings'][$y]['default_setting_category'] = "backup_manager";
+$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "auto_backup_enabled";
+$apps[$x]['default_settings'][$y]['default_setting_name'] = "boolean";
+$apps[$x]['default_settings'][$y]['default_setting_value'] = "false";
+$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
+$y++;
+$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "d2e0b8a2-b7d2-4eaa-8d2a-001122334455";
+$apps[$x]['default_settings'][$y]['default_setting_category'] = "backup_manager";
+$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "auto_backup_frequency";
+$apps[$x]['default_settings'][$y]['default_setting_name'] = "text";
+$apps[$x]['default_settings'][$y]['default_setting_value'] = "daily";
+$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
+$y++;
+$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "e3e0b8a2-b7d2-4eaa-8d2a-001122334455";
+$apps[$x]['default_settings'][$y]['default_setting_category'] = "backup_manager";
+$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "auto_backup_keep";
+$apps[$x]['default_settings'][$y]['default_setting_name'] = "numeric";
+$apps[$x]['default_settings'][$y]['default_setting_value'] = "7";
+$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
+
 

--- a/app/backup_manager/app_defaults.php
+++ b/app/backup_manager/app_defaults.php
@@ -1,0 +1,35 @@
+<?php
+// process once on install
+if ($domains_processed == 1) {
+    // insert default settings if they do not exist
+    $defaults = [
+        ['uuid'=>'c1e0b8a2-b7d2-4eaa-8d2a-001122334455','category'=>'backup_manager','subcategory'=>'auto_backup_enabled','name'=>'boolean','value'=>'false'],
+        ['uuid'=>'d2e0b8a2-b7d2-4eaa-8d2a-001122334455','category'=>'backup_manager','subcategory'=>'auto_backup_frequency','name'=>'text','value'=>'daily'],
+        ['uuid'=>'e3e0b8a2-b7d2-4eaa-8d2a-001122334455','category'=>'backup_manager','subcategory'=>'auto_backup_keep','name'=>'numeric','value'=>'7'],
+    ];
+    $p = permissions::new();
+    $p->add('default_setting_add','temp');
+    $p->add('default_setting_edit','temp');
+    foreach ($defaults as $row) {
+        $sql = "select count(*) from v_default_settings where default_setting_uuid = :uuid";
+        $params = ['uuid'=>$row['uuid']];
+        $count = $database->select($sql, $params, 'column');
+        if ($count == 0) {
+            $array['default_settings'][0] = [
+                'default_setting_uuid'=>$row['uuid'],
+                'default_setting_category'=>$row['category'],
+                'default_setting_subcategory'=>$row['subcategory'],
+                'default_setting_name'=>$row['name'],
+                'default_setting_value'=>$row['value'],
+                'default_setting_enabled'=>'true'
+            ];
+            $database->app_name = 'backup_manager';
+            $database->app_uuid = 'b45cc3a6-1f4e-4f9d-8c69-3a065e1d2d1a';
+            $database->save($array);
+            unset($array);
+        }
+    }
+    $p->delete('default_setting_add','temp');
+    $p->delete('default_setting_edit','temp');
+}
+?>

--- a/app/backup_manager/download.php
+++ b/app/backup_manager/download.php
@@ -1,0 +1,22 @@
+<?php
+require_once dirname(__DIR__, 2) . "/resources/require.php";
+require_once "resources/check_auth.php";
+
+//check permission
+if (!permission_exists('backup_manager_backup')) {
+    echo "access denied";
+    exit;
+}
+
+$file = basename($_GET['file'] ?? '');
+$path = '/var/backups/fusionpbx/' . $file;
+
+if ($file && file_exists($path)) {
+    header('Content-Type: application/octet-stream');
+    header('Content-Disposition: attachment; filename="' . $file . '"');
+    readfile($path);
+    exit;
+}
+
+echo "File not found";
+?>

--- a/app/backup_manager/restore.php
+++ b/app/backup_manager/restore.php
@@ -13,6 +13,7 @@ if (!permission_exists('backup_manager_restore')) {
 }
 
 $message = '';
+$selected_file = $_GET['file'] ?? '';
 if (!empty($_POST['action']) && $_POST['action'] === 'restore') {
     $backup_file = escapeshellarg('/var/backups/fusionpbx/' . $_POST['backup_file']);
     $options     = $_POST['restore_options'] ?? [];
@@ -37,7 +38,8 @@ echo '<input type="hidden" name="action" value="restore" />';
 echo '<label>Select Backup File:</label><br/>';
 echo '<select name="backup_file">';
 foreach (array_filter(scandir('/var/backups/fusionpbx', SCANDIR_SORT_DESCENDING), function($f){return preg_match('/\.tgz$/', $f);} ) as $file) {
-    echo '<option>' . htmlspecialchars($file) . '</option>';
+    $sel = $selected_file === $file ? 'selected' : '';
+    echo '<option value="' . htmlspecialchars($file) . '" ' . $sel . '>' . htmlspecialchars($file) . '</option>';
 }
 echo '</select><br/><br/>';
 


### PR DESCRIPTION
## Summary
- create download endpoint for backups
- enhance restore to preselect a file
- extend backup manager with settings and actions
- register backup manager defaults
- add install script for defaults

## Testing
- `php -l app/backup_manager/backup.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68646d3372748329beb26bd745da7262