### PR TITLE
Update backup manager restore options

### DIFF
--- a/app/backup_manager/restore.php
+++ b/app/backup_manager/restore.php
@@ -16,12 +16,12 @@ $message = '';
 $selected_file = $_GET['file'] ?? '';
 if (!empty($_POST['action']) && $_POST['action'] === 'restore') {
     $backup_file = escapeshellarg('/var/backups/fusionpbx/' . $_POST['backup_file']);
-    $options     = $_POST['restore_options'] ?? [];
+    $option      = $_POST['restore_option'] ?? 'full';
     // Pre-restore safety dump
     exec('sudo /usr/local/bin/fusionpbx-pre-restore.sh');
-    // Extract and restore based on options
+    // Extract and restore based on option
     $script = '/usr/local/bin/fusionpbx-restore-manager.sh';
-    $cmd = 'sudo ' . escapeshellarg($script) . ' ' . $backup_file . ' ' . implode(',', $options) . ' 2>&1';
+    $cmd = 'sudo ' . escapeshellarg($script) . ' ' . $backup_file . ' ' . escapeshellarg($option) . ' 2>&1';
     exec($cmd, $output, $status);
     $message = $status === 0 ? 'Restore completed successfully.' : 'Restore failed!';
 }
@@ -43,10 +43,9 @@ foreach (array_filter(scandir('/var/backups/fusionpbx', SCANDIR_SORT_DESCENDING)
 }
 echo '</select><br/><br/>';
 
-echo '<label>Restore Options:</label><br/>';
-echo '<input type="checkbox" name="restore_options[]" value="db" /> Database (Config & CDRs)<br/>';
-echo '<input type="checkbox" name="restore_options[]" value="media" /> Voicemails & Recordings<br/>';
-echo '<input type="checkbox" name="restore_options[]" value="certs" /> SSL Certificates<br/><br/>';
+echo '<label>Restore Type:</label><br/>';
+echo '<label><input type="radio" name="restore_option" value="full" checked /> Full Backup</label><br/>';
+echo '<label><input type="radio" name="restore_option" value="media" /> Recordings, Music & Storage Only</label><br/><br/>';
 
 echo '<button type="submit" class="btn">Run Restore</button>';
 echo '</form>';

--- a/app/backup_manager/scripts/fusionpbx-backup-manager.sh
+++ b/app/backup_manager/scripts/fusionpbx-backup-manager.sh
@@ -1,41 +1,32 @@
-//------------------------------------------------------------------------------
-// scripts/fusionpbx-backup-manager.sh
-// Sample backup script: make executable and allow sudo without password for www-data
-//------------------------------------------------------------------------------
 #!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# fusionpbx-backup-manager.sh
+# Create a FusionPBX backup. Intended to be run via sudo by the web interface.
+# -----------------------------------------------------------------------------
 set -euo pipefail
 
-# Ruta al config de FusionPBX
+BASEDIR="/var/backups/fusionpbx"
+mkdir -p "$BASEDIR/postgresql"
+now=$(date +"%Y%m%d_%H%M%S")
+
 CONFIG_FILE=/etc/fusionpbx/config.conf
 
-# Función helper para leer clave=valor y recortar espacios
 _read_conf() {
   local key="$1"
-  grep -E "^${key}" "$CONFIG_FILE" \
-    | head -n1 \
-    | cut -d'=' -f2- \
-    | tr -d '[:space:]'
+  grep -E "^${key}" "$CONFIG_FILE" | head -n1 | cut -d'=' -f2- | tr -d '[:space:]'
 }
 
-# Extraer variables de conexión
 DB_HOST=$(_read_conf 'database\.0\.host')
 DB_PORT=$(_read_conf 'database\.0\.port')
 DB_NAME=$(_read_conf 'database\.0\.name')
 DB_USER=$(_read_conf 'database\.0\.username')
 DB_PASS=$(_read_conf 'database\.0\.password')
 
-# Exportar contraseña para pg_dump/psql
 export PGPASSWORD="$DB_PASS"
-# Dump de la base de datos
-pg_dump \
-  -h "$DB_HOST" \
-  -p "$DB_PORT" \
-  -U "$DB_USER" \
-  -Fc "$DB_NAME" \
+pg_dump -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -Fc "$DB_NAME" \
   -f "$BASEDIR/postgresql/fusionpbx_${now}.sql"
 
-# Empaquetar archivos
-tar -zvcf "$BASEDIR/backup_${now}.tgz" \
+tar -zcf "$BASEDIR/backup_${now}.tgz" \
   "$BASEDIR/postgresql/fusionpbx_${now}.sql" \
   /etc/fusionpbx \
   /var/www/fusionpbx \
@@ -44,8 +35,7 @@ tar -zvcf "$BASEDIR/backup_${now}.tgz" \
   /etc/freeswitch \
   /var/lib/freeswitch/recordings \
   /var/lib/freeswitch/storage \
-  /etc/freeswitch \
   /etc/dehydrated
 
-# Limpieza de backups antiguos (por ejemplo, más de 7 días)
 find "$BASEDIR" -type f -mtime +7 -delete
+

--- a/app/backup_manager/scripts/fusionpbx-restore-manager.sh
+++ b/app/backup_manager/scripts/fusionpbx-restore-manager.sh
@@ -1,32 +1,76 @@
-//------------------------------------------------------------------------------
-// scripts/fusionpbx-restore-manager.sh
-// Sample restore script: pass backup file and comma-separated options (db,media,certs)
-//------------------------------------------------------------------------------
-#!/bin/bash
-BACKUP_TGZ=$1
-OPTIONS=$2
-# extract backup
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# fusionpbx-restore-manager.sh
+# Restore a FusionPBX backup. Usage: script <backup.tgz> <full|media>
+# -----------------------------------------------------------------------------
+set -euo pipefail
+
+BACKUP_TGZ="$1"
+MODE="${2:-full}"
+
 TMPDIR=$(mktemp -d)
-tar -xzvf "$BACKUP_TGZ" -C "$TMPDIR"
-# restore DB
-if [[ ",\$OPTIONS," == *",db,"* ]]; then
-  echo "Restoring database..."
-  psql -U fusionpbx -c "DROP SCHEMA public CASCADE;"
-  psql -U fusionpbx -c "CREATE SCHEMA public;"
-  pg_restore -v -Fc --dbname=fusionpbx "$TMPDIR/postgresql/fusionpbx_*.sql"
-fi
-# restore media
-if [[ ",\$OPTIONS," == *",media,"* ]]; then
-  echo "Restoring media files..."
-  cp -r "$TMPDIR/var/lib/freeswitch/storage/"* /var/lib/freeswitch/storage/
-  cp -r "$TMPDIR/var/lib/freeswitch/recordings/"* /var/lib/freeswitch/recordings/
-fi
-# restore certs
-if [[ ",\$OPTIONS," == *",certs,"* ]]; then
-  echo "Restoring certificates..."
-  cp -r "$TMPDIR/etc/dehydrated" /etc/
-fi
-# reload services
+tar -xzf "$BACKUP_TGZ" -C "$TMPDIR"
+
+CONFIG_FILE=/etc/fusionpbx/config.conf
+
+_read_conf() {
+  local key="$1"
+  grep -E "^${key}" "$CONFIG_FILE" | head -n1 | cut -d'=' -f2- | tr -d '[:space:]'
+}
+
+DB_HOST=$(_read_conf 'database\.0\.host')
+DB_PORT=$(_read_conf 'database\.0\.port')
+DB_NAME=$(_read_conf 'database\.0\.name')
+DB_USER=$(_read_conf 'database\.0\.username')
+DB_PASS=$(_read_conf 'database\.0\.password')
+export PGPASSWORD="$DB_PASS"
+
+restore_db() {
+  SQL_FILE=$(find "$TMPDIR/postgresql" -name 'fusionpbx_*.sql' -print -quit)
+  if [[ -f "$SQL_FILE" ]]; then
+    psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -c "DROP SCHEMA public CASCADE;"
+    psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -c "CREATE SCHEMA public;"
+    pg_restore -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -v -Fc --dbname="$DB_NAME" "$SQL_FILE"
+  fi
+}
+
+restore_all_files() {
+  rsync -a "$TMPDIR/etc/fusionpbx/" /etc/fusionpbx/
+  rsync -a "$TMPDIR/var/www/fusionpbx/" /var/www/fusionpbx/
+  rsync -a "$TMPDIR/usr/share/freeswitch/scripts/" /usr/share/freeswitch/scripts/
+  rsync -a "$TMPDIR/etc/freeswitch/" /etc/freeswitch/
+  restore_media_only
+  rsync -a "$TMPDIR/etc/dehydrated/" /etc/dehydrated/
+}
+
+restore_media_only() {
+  rsync -a "$TMPDIR/usr/share/freeswitch/sounds/music/" /usr/share/freeswitch/sounds/music/
+  rsync -a "$TMPDIR/var/lib/freeswitch/recordings/" /var/lib/freeswitch/recordings/
+  rsync -a "$TMPDIR/var/lib/freeswitch/storage/" /var/lib/freeswitch/storage/
+}
+
+case "$MODE" in
+  full)
+    restore_db
+    restore_all_files
+    ;;
+  media)
+    restore_media_only
+    ;;
+  *)
+    IFS=',' read -ra opts <<< "$MODE"
+    for opt in "${opts[@]}"; do
+      case "$opt" in
+        db) restore_db ;;
+        media) restore_media_only ;;
+        certs) rsync -a "$TMPDIR/etc/dehydrated/" /etc/dehydrated/ ;;
+      esac
+    done
+    ;;
+esac
+
 service freeswitch restart
 service nginx reload
+
 echo "Restore complete."
+


### PR DESCRIPTION
## Summary
- refine restore.php with full or media-only options
- fix backup and restore shell scripts and add DB config parsing
- allow selecting restore type from the UI

## Testing
- `php -l app/backup_manager/restore.php` *(fails: command not found)*
- `shellcheck app/backup_manager/scripts/fusionpbx-backup-manager.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869a30c9a708329bb171b07f9382bf7