### PR TITLE
Improve backup deletion feedback

### DIFF
--- a/app/backup_manager/backup.php
+++ b/app/backup_manager/backup.php
@@ -37,8 +37,11 @@ if (!empty($_GET['delete'])) {
     $del = basename($_GET['delete']);
     $path = '/var/backups/fusionpbx/' . $del;
     if (file_exists($path)) {
-        unlink($path);
-        $message = 'Backup deleted.';
+        if (unlink($path)) {
+            $message = 'Backup deleted.';
+        } else {
+            $message = 'Failed to delete backup.';
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- show delete success/failure in backup manager

## Testing
- `php -l app/backup_manager/backup.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ad31ad8b88329aafd1b536e998f46