### PR TITLE
Improve backup deletion error logging

### DIFF
--- a/app/backup_manager/backup.php
+++ b/app/backup_manager/backup.php
@@ -40,7 +40,10 @@ if (!empty($_GET['delete'])) {
         if (unlink($path)) {
             $message = 'Backup deleted.';
         } else {
-            $message = 'Failed to delete backup.';
+            $err = error_get_last();
+            $error_msg = $err['message'] ?? 'unknown error';
+            error_log("Failed to delete backup file $path: $error_msg");
+            $message = 'Failed to delete backup. ' . $error_msg;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add detailed logging when backups fail to delete

## Testing
- `php -l app/backup_manager/backup.php`
- `php /tmp/test_unlink.php 2> /tmp/php_error.log`

------
https://chatgpt.com/codex/tasks/task_e_686ad790e8f48329898a58c2d4f0f017