### PR TITLE
Fix restore path

### DIFF
--- a/app/backup_manager/restore.php
+++ b/app/backup_manager/restore.php
@@ -18,18 +18,25 @@ if (!empty($_POST['action']) && $_POST['action'] === 'restore') {
     $backup_file = escapeshellarg('/var/backups/fusionpbx/' . $_POST['backup_file']);
     $option      = $_POST['restore_option'] ?? 'full';
     // Pre-restore safety dump
-    exec('sudo /usr/local/bin/fusionpbx-pre-restore.sh');
+    $pre = '/var/www/fusionpbx/app/backup_manager/scripts/fusionpbx-pre-restore.sh';
+    $pre_output = [];
+    exec('sudo ' . escapeshellarg($pre) . ' 2>&1', $pre_output, $pre_status);
     // Extract and restore based on option
     $script = '/var/www/fusionpbx/app/backup_manager/scripts/fusionpbx-restore-manager.sh';
     $cmd = 'sudo ' . escapeshellarg($script) . ' ' . $backup_file . ' ' . escapeshellarg($option) . ' 2>&1';
+    $output = [];
     exec($cmd, $output, $status);
     $message = $status === 0 ? 'Restore completed successfully.' : 'Restore failed!';
+    $output = array_merge($pre_output, $output);
 }
 
 require_once "resources/header.php";
 echo '<h2>Restore Manager</h2>';
 if ($message) {
     echo "<div class='message'>$message</div>";
+    if (!empty($output)) {
+        echo '<pre>' . htmlspecialchars(implode(PHP_EOL, $output)) . '</pre>';
+    }
 }
 
 echo '<form method="post">';

--- a/app/backup_manager/scripts/fusionpbx-pre-restore.sh
+++ b/app/backup_manager/scripts/fusionpbx-pre-restore.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# fusionpbx-pre-restore.sh
+# Prepare the system before running a FusionPBX restore.
+# This script creates a safety backup and stops services to avoid conflicts.
+# -----------------------------------------------------------------------------
+set -euo pipefail
+
+BACKUP_SCRIPT="/var/www/fusionpbx/app/backup_manager/scripts/fusionpbx-backup-manager.sh"
+
+if [[ -x "$BACKUP_SCRIPT" ]]; then
+  echo "Creating pre-restore backup..."
+  "$BACKUP_SCRIPT"
+else
+  echo "Backup script not found: $BACKUP_SCRIPT" >&2
+  exit 1
+fi
+
+# Stop services to ensure files are consistent during restore
+service freeswitch stop
+service nginx stop
+
+echo "Pre-restore tasks completed."

--- a/app/backup_manager/scripts/fusionpbx-restore-manager.sh
+++ b/app/backup_manager/scripts/fusionpbx-restore-manager.sh
@@ -26,7 +26,8 @@ DB_PASS=$(_read_conf 'database\.0\.password')
 export PGPASSWORD="$DB_PASS"
 
 restore_db() {
-  SQL_FILE=$(find "$TMPDIR/postgresql" -name 'fusionpbx_*.sql' -print -quit)
+  # SQL dumps reside under var/backups when extracted
+  SQL_FILE=$(find "$TMPDIR" -path '*/postgresql/fusionpbx_*.sql' -print -quit)
   if [[ -f "$SQL_FILE" ]]; then
     psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -c "DROP SCHEMA public CASCADE;"
     psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -c "CREATE SCHEMA public;"


### PR DESCRIPTION
## Summary
- update the restore manager to search for the SQL dump in the extracted backup structure
- create a pre-restore safety backup script that stops services before restore
- call the pre-restore script from restore.php and display output

## Testing
- `bash -n app/backup_manager/scripts/fusionpbx-pre-restore.sh`
- `bash -n app/backup_manager/scripts/fusionpbx-restore-manager.sh`
- `php -l app/backup_manager/restore.php`


------
https://chatgpt.com/codex/tasks/task_e_686ae3fe3a7c8329900c5a595afea4d6