### PR TITLE
Fix backup manager settings initialization

### DIFF
--- a/app/backup_manager/backup.php
+++ b/app/backup_manager/backup.php
@@ -7,6 +7,15 @@
 require_once dirname(__DIR__, 2) . "/resources/require.php";
 require_once "resources/check_auth.php";
 
+//ensure settings object exists when check_auth is bypassed
+if (!isset($settings) || !is_object($settings)) {
+    $settings = new settings([
+        'database' => $database,
+        'domain_uuid' => $_SESSION['domain_uuid'] ?? '',
+        'user_uuid' => $_SESSION['user_uuid'] ?? ''
+    ]);
+}
+
 //check permissions
 if (!permission_exists('backup_manager_backup')) {
     echo "access denied";


### PR DESCRIPTION
## Summary
- ensure `$settings` is initialized in `backup.php` when `check_auth.php` doesn't

## Testing
- `php -l app/backup_manager/backup.php`

------
https://chatgpt.com/codex/tasks/task_e_687179b2546883299b5721742b14f030