### PR TITLE
Fix restore manager missing settings object

### DIFF
--- a/app/backup_manager/restore.php
+++ b/app/backup_manager/restore.php
@@ -6,6 +6,15 @@
 require_once dirname(__DIR__, 2) . "/resources/require.php";
 require_once "resources/check_auth.php";
 
+//ensure settings object exists when check_auth is bypassed
+if (!isset($settings) || !is_object($settings)) {
+    $settings = new settings([
+        'database' => $database,
+        'domain_uuid' => $_SESSION['domain_uuid'] ?? '',
+        'user_uuid' => $_SESSION['user_uuid'] ?? ''
+    ]);
+}
+
 //check permissions
 if (!permission_exists('backup_manager_restore')) {
     echo "access denied";


### PR DESCRIPTION
## Summary
- ensure `$settings` exists when backup restore UI loads

## Testing
- `php -l app/backup_manager/restore.php`

------
https://chatgpt.com/codex/tasks/task_e_6871aa85771083299e4a6764619843e5