### PR TITLE
Switch to count-based backups

### DIFF
--- a/app/backup_manager/backup.php
+++ b/app/backup_manager/backup.php
@@ -52,7 +52,7 @@ function update_backup_cron(array $settings): bool {
             $day_of_month = (int)$settings['day_of_month'];
             break;
     }
-    $entry = sprintf('%d %d %s * %s KEEP_DAYS=%d sudo %s > /dev/null 2>&1 %s',
+    $entry = sprintf('%d %d %s * %s KEEP_COUNT=%d sudo %s > /dev/null 2>&1 %s',
         (int)$minute,
         (int)$hour,
         $day_of_month,

--- a/app/backup_manager/scripts/fusionpbx-backup-manager.sh
+++ b/app/backup_manager/scripts/fusionpbx-backup-manager.sh
@@ -37,6 +37,14 @@ tar -zcf "$BASEDIR/backup_${now}.tgz" \
   /var/lib/freeswitch/storage \
   /etc/dehydrated
 
-KEEP_DAYS="${KEEP_DAYS:-7}"
-find "$BASEDIR" -type f -mtime +"$KEEP_DAYS" -delete
+KEEP_COUNT="${KEEP_COUNT:-7}"
+mapfile -t backups < <(ls -1t "$BASEDIR"/backup_*.tgz 2>/dev/null || true)
+if (( ${#backups[@]} > KEEP_COUNT )); then
+  for file in "${backups[@]:KEEP_COUNT}"; do
+    rm -f "$file"
+    if [[ $file =~ backup_(.*)\.tgz$ ]]; then
+      rm -f "$BASEDIR/postgresql/fusionpbx_${BASH_REMATCH[1]}.sql"
+    fi
+  done
+fi
 


### PR DESCRIPTION
## Summary
- allow specifying how many backups to keep
- remove outdated backups based on count rather than age

## Testing
- `php -l app/backup_manager/backup.php`
- `bash -n app/backup_manager/scripts/fusionpbx-backup-manager.sh`
- `lua app/switch/resources/scripts/resources/tests/self_test.lua` *(fails: module 'resources.functions.cache' not found)*


------
https://chatgpt.com/codex/tasks/task_e_687424a9e2a48329b068090edceda40d