### PR TITLE
Fix backup retention count

### DIFF
--- a/app/backup_manager/backup.php
+++ b/app/backup_manager/backup.php
@@ -52,7 +52,7 @@ function update_backup_cron(array $settings): bool {
             $day_of_month = (int)$settings['day_of_month'];
             break;
     }
-    $entry = sprintf('%d %d %s * %s KEEP_COUNT=%d sudo %s > /dev/null 2>&1 %s',
+    $entry = sprintf('%d %d %s * %s sudo KEEP_COUNT=%d %s > /dev/null 2>&1 %s',
         (int)$minute,
         (int)$hour,
         $day_of_month,
@@ -89,7 +89,8 @@ if (!empty($_POST['action']) && $_POST['action'] === 'backup') {
     // Path to your backup script
     $script = '/var/www/fusionpbx/app/backup_manager/scripts/fusionpbx-backup-manager.sh';
     // Execute backup (ensure www-data has sudo rights for this script)
-    $cmd = 'sudo ' . escapeshellarg($script) . ' 2>&1';
+    $keep = (int)$backup_settings['keep'];
+    $cmd = 'sudo KEEP_COUNT=' . $keep . ' ' . escapeshellarg($script) . ' 2>&1';
     exec($cmd, $output, $status);
     $log_entry = date('Y-m-d H:i:s') . "\nCMD: $cmd\n" .
         "STATUS: $status\n" .


### PR DESCRIPTION
## Summary
- ensure backup retention uses the selected number
- pass KEEP_COUNT through sudo for cron and manual runs

## Testing
- `php -l app/backup_manager/backup.php`

------
https://chatgpt.com/codex/tasks/task_e_688ce2f0c3008329a1b04849c6864605