### PR TITLE
feat(backup): pass retention count as argument

### DIFF
--- a/app/backup_manager/backup.php
+++ b/app/backup_manager/backup.php
@@ -52,13 +52,13 @@ function update_backup_cron(array $settings): bool {
             $day_of_month = (int)$settings['day_of_month'];
             break;
     }
-    $entry = sprintf('%d %d %s * %s sudo KEEP_COUNT=%d %s > /dev/null 2>&1 %s',
+    $entry = sprintf('%d %d %s * %s sudo %s %d > /dev/null 2>&1 %s',
         (int)$minute,
         (int)$hour,
         $day_of_month,
         $day_of_week,
-        (int)$settings['keep'],
         $script,
+        (int)$settings['keep'],
         $cron_id
     );
 
@@ -90,7 +90,7 @@ if (!empty($_POST['action']) && $_POST['action'] === 'backup') {
     $script = '/var/www/fusionpbx/app/backup_manager/scripts/fusionpbx-backup-manager.sh';
     // Execute backup (ensure www-data has sudo rights for this script)
     $keep = (int)$backup_settings['keep'];
-    $cmd = 'sudo KEEP_COUNT=' . $keep . ' ' . escapeshellarg($script) . ' 2>&1';
+    $cmd = 'sudo ' . escapeshellarg($script) . ' ' . $keep . ' 2>&1';
     exec($cmd, $output, $status);
     $log_entry = date('Y-m-d H:i:s') . "\nCMD: $cmd\n" .
         "STATUS: $status\n" .

--- a/app/backup_manager/scripts/fusionpbx-backup-manager.sh
+++ b/app/backup_manager/scripts/fusionpbx-backup-manager.sh
@@ -37,9 +37,11 @@ tar -zcf "$BASEDIR/backup_${now}.tgz" \
   /var/lib/freeswitch/storage \
   /etc/dehydrated
 
-KEEP_COUNT="${KEEP_COUNT:-7}"
+# allow keep count via first argument or environment variable; default to 7
+KEEP_COUNT="${1:-${KEEP_COUNT:-7}}"
+
 mapfile -t backups < <(ls -1t "$BASEDIR"/backup_*.tgz 2>/dev/null || true)
-if (( ${#backups[@]} > KEEP_COUNT )); then
+if (( KEEP_COUNT > 0 && ${#backups[@]} > KEEP_COUNT )); then
   for file in "${backups[@]:KEEP_COUNT}"; do
     rm -f "$file"
     if [[ $file =~ backup_(.*)\.tgz$ ]]; then


### PR DESCRIPTION
## Summary
- ensure cron job passes keep count directly to backup script
- allow backup script to read keep count from argument and skip purging when zero

## Testing
- `php -l app/backup_manager/backup.php`
- `bash -n app/backup_manager/scripts/fusionpbx-backup-manager.sh`


------
https://chatgpt.com/codex/tasks/task_e_6893de18cc648329b3aa543d6f7fe6a4