### PR TITLE
backup_manager: respect keep setting in cron backups

### DIFF
--- a/app/backup_manager/backup.php
+++ b/app/backup_manager/backup.php
@@ -52,13 +52,12 @@ function update_backup_cron(array $settings): bool {
             $day_of_month = (int)$settings['day_of_month'];
             break;
     }
-    $entry = sprintf('%d %d %s * %s sudo %s %d > /dev/null 2>&1 %s',
+    $entry = sprintf('%d %d %s * %s sudo %s > /dev/null 2>&1 %s',
         (int)$minute,
         (int)$hour,
         $day_of_month,
         $day_of_week,
         $script,
-        (int)$settings['keep'],
         $cron_id
     );
 
@@ -89,8 +88,7 @@ if (!empty($_POST['action']) && $_POST['action'] === 'backup') {
     // Path to your backup script
     $script = '/var/www/fusionpbx/app/backup_manager/scripts/fusionpbx-backup-manager.sh';
     // Execute backup (ensure www-data has sudo rights for this script)
-    $keep = (int)$backup_settings['keep'];
-    $cmd = 'sudo ' . escapeshellarg($script) . ' ' . $keep . ' 2>&1';
+    $cmd = 'sudo ' . escapeshellarg($script) . ' 2>&1';
     exec($cmd, $output, $status);
     $log_entry = date('Y-m-d H:i:s') . "\nCMD: $cmd\n" .
         "STATUS: $status\n" .

--- a/app/backup_manager/scripts/fusionpbx-backup-manager.sh
+++ b/app/backup_manager/scripts/fusionpbx-backup-manager.sh
@@ -10,6 +10,7 @@ mkdir -p "$BASEDIR/postgresql"
 now=$(date +"%Y%m%d_%H%M%S")
 
 CONFIG_FILE=/etc/fusionpbx/config.conf
+SETTINGS_FILE="$BASEDIR/backup_settings.json"
 
 _read_conf() {
   local key="$1"
@@ -37,8 +38,12 @@ tar -zcf "$BASEDIR/backup_${now}.tgz" \
   /var/lib/freeswitch/storage \
   /etc/dehydrated
 
-# allow keep count via first argument or environment variable; default to 7
-KEEP_COUNT="${1:-${KEEP_COUNT:-7}}"
+# determine keep count
+KEEP_COUNT="${1:-${KEEP_COUNT:-}}"
+if [[ -z "$KEEP_COUNT" && -f "$SETTINGS_FILE" ]]; then
+  KEEP_COUNT=$(php -r "echo (int)json_decode(file_get_contents('$SETTINGS_FILE'), true)['keep'];")
+fi
+KEEP_COUNT="${KEEP_COUNT:-7}"
 
 mapfile -t backups < <(ls -1t "$BASEDIR"/backup_*.tgz 2>/dev/null || true)
 if (( KEEP_COUNT > 0 && ${#backups[@]} > KEEP_COUNT )); then


### PR DESCRIPTION
## Summary
- load retention value from backup_settings.json inside backup manager script
- drop explicit keep parameter when running backups or writing cron entries

## Testing
- `php -l app/backup_manager/backup.php`
- `bash -n app/backup_manager/scripts/fusionpbx-backup-manager.sh`


------
https://chatgpt.com/codex/tasks/task_e_6895185f71f483299e7123bbbaaa6a68