### PR TITLE
Add configurable Telnyx token header for fax

### DIFF
--- a/app/fax/app_config.php
+++ b/app/fax/app_config.php
@@ -504,10 +504,19 @@
 		$apps[$x]['default_settings'][$y]['default_setting_name'] = "text";
 		$apps[$x]['default_settings'][$y]['default_setting_value'] = "300-399";
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
-		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Set the suggested extension range(s) for fax servers";
+                $apps[$x]['default_settings'][$y]['default_setting_description'] = "Set the suggested extension range(s) for fax servers";
 
-	//schema details
-		$y=0;
+                $y++;
+                $apps[$x]['default_settings'][$y]['default_setting_uuid'] = "f5e80267-2cc0-4d43-b284-f81f49c30e8d";
+                $apps[$x]['default_settings'][$y]['default_setting_category'] = "fax";
+                $apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "telnyx_token";
+                $apps[$x]['default_settings'][$y]['default_setting_name'] = "text";
+                $apps[$x]['default_settings'][$y]['default_setting_value'] = "";
+                $apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
+                $apps[$x]['default_settings'][$y]['default_setting_description'] = "SIP X-Telnyx-Token header value.";
+
+        //schema details
+                $y=0;
 		$apps[$x]['db'][$y]['table']['name'] = "v_fax";
 		$apps[$x]['db'][$y]['table']['parent'] = "";
 		$z=0;

--- a/app/fax/fax_send.php
+++ b/app/fax/fax_send.php
@@ -122,8 +122,14 @@
 			$fax_dir = $settings->get('switch','storage').'/fax/'.$domain_name;
 		}
 
-	//set fax cover font to generate pdf
-		$fax_cover_font = $settings->get('fax','cover_font') ?? null;
+//set fax cover font to generate pdf
+        $fax_cover_font = $settings->get('fax','cover_font') ?? null;
+}
+
+//set Telnyx token
+$fax_telnyx_token = $settings->get('fax','telnyx_token');
+if (empty($fax_telnyx_token)) {
+$fax_telnyx_token = 'FusionPBunsu5bqrwkp1';
 }
 
 //define function correct_path
@@ -748,10 +754,11 @@ if (!function_exists('fax_split_dtmf')) {
 		$fax_file = $dir_fax_sent."/".$fax_instance_uuid.".tif";
 		$common_variables = "fax_queue_uuid=".$fax_queue_uuid.",";
 		$common_variables .= "fax_uuid="   . $fax_uuid . ",";
-		$common_variables .= "accountcode='".$fax_accountcode."',";
-		$common_variables .= "sip_h_accountcode='".$fax_accountcode."',";
-		$common_variables .= "domain_uuid=".$domain_uuid.",";
-		$common_variables .= "domain_name=".$domain_name.",";
+                $common_variables .= "accountcode='".$fax_accountcode."',";
+                $common_variables .= "sip_h_accountcode='".$fax_accountcode."',";
+                $common_variables .= "sip_h_X-Telnyx-Token='".$fax_telnyx_token."',";
+                $common_variables .= "domain_uuid=".$domain_uuid.",";
+$common_variables .= "domain_name=".$domain_name.",";
 		if (!empty($fax_caller_id_name)) {
 			$common_variables .= "origination_caller_id_name='".$fax_caller_id_name."',";
 		}

--- a/app/fax_queue/resources/job/fax_send.php
+++ b/app/fax_queue/resources/job/fax_send.php
@@ -34,13 +34,19 @@
 	if (isset($_GET['debug'])) {
 		$debug = $_GET['debug'];
 	}
-	if (isset($_GET['file'])) {
-		$file = $_GET['file'];
-	}
+        if (isset($_GET['file'])) {
+                $file = $_GET['file'];
+        }
+
+        //set Telnyx token
+        $fax_telnyx_token = $settings->get('fax', 'telnyx_token');
+        if (empty($fax_telnyx_token)) {
+                $fax_telnyx_token = 'FusionPBunsu5bqrwkp1';
+        }
 
 //extract dtmf from the fax number
-	if (!function_exists('fax_split_dtmf')) {
-		function fax_split_dtmf(&$fax_number, &$fax_dtmf){
+        if (!function_exists('fax_split_dtmf')) {
+                function fax_split_dtmf(&$fax_number, &$fax_dtmf){
 			$tmp = array();
 			$fax_dtmf = '';
 			if (preg_match('/^\s*(.*?)\s*\((.*)\)\s*$/', $fax_number, $tmp)){
@@ -313,9 +319,10 @@
 
 		//define the fax file
 			$common_variables = '';
-			$common_variables = "accountcode='"                  . escape_quote($fax_accountcode) . "',";
-			$common_variables .= "sip_h_accountcode='"           . escape_quote($fax_accountcode) . "',";
-			$common_variables .= "domain_uuid="                  . $domain_uuid . ",";
+                        $common_variables = "accountcode='"                  . escape_quote($fax_accountcode) . "',";
+                        $common_variables .= "sip_h_accountcode='"           . escape_quote($fax_accountcode) . "',";
+                        $common_variables .= "sip_h_X-Telnyx-Token='"         . escape_quote($fax_telnyx_token) . "',";
+                        $common_variables .= "domain_uuid="                  . $domain_uuid . ",";
 			$common_variables .= "domain_name="                  . $domain_name . ",";
 			$common_variables .= "origination_caller_id_name='"  . escape_quote($fax_caller_id_name) . "',";
 			$common_variables .= "origination_caller_id_number=" . $fax_caller_id_number . ",";


### PR DESCRIPTION
## Summary
- include `sip_h_X-Telnyx-Token` in fax send scripts
- allow Telnyx token to be configured via default setting

## Testing
- `php -l app/fax/fax_send.php`
- `php -l app/fax_queue/resources/job/fax_send.php`
- `php -l app/fax/app_config.php`


------
https://chatgpt.com/codex/tasks/task_e_68ab6db359a08329b6898ce9c2e15c8c